### PR TITLE
Change overflow-y value from scroll to auto in the NavLinks container (fix #7 PR)

### DIFF
--- a/components/Nav/parts/NavLinks.tsx
+++ b/components/Nav/parts/NavLinks.tsx
@@ -15,7 +15,7 @@ const NavLinks = styled.div<Props>`
 
     flex-direction: column;
     justify-content: flex-start;
-    overflow-y: scroll;
+    overflow-y: auto;
 
     position: fixed;
     width: var(--width);

--- a/public/rss.xml
+++ b/public/rss.xml
@@ -4,7 +4,7 @@
         <description><![CDATA[Robert Orliński | Programuję i dzielę się wiedzą o programowaniu 🚀]]></description>
         <link>http://localhost:3000</link>
         <generator>RSS for Node</generator>
-        <lastBuildDate>Thu, 26 May 2022 18:55:34 GMT</lastBuildDate>
+        <lastBuildDate>Sat, 02 Jul 2022 10:55:08 GMT</lastBuildDate>
         <atom:link href="http://localhost:3000/rss.xml" rel="self" type="application/rss+xml"/>
         <copyright><![CDATA[2022 Robert Orliński]]></copyright>
         <language><![CDATA[pl]]></language>


### PR DESCRIPTION
This PR deliver more appropriate solution for issue presented in #6 issue and replace code from #7 PR. `Scroll-y: auto` provides, in more intelligent way, a scroll bar only when it is necessary instead of adding it in all cases.