### PR TITLE
Fix bug in getISOStringFromPublicationDate.ts

### DIFF
--- a/helpers/functions/getISOStringFromPublicationDate.ts
+++ b/helpers/functions/getISOStringFromPublicationDate.ts
@@ -3,7 +3,7 @@ const getISOStringFromPublicationDate = (date: string): string => {
 
   return new Date(
     Number(splittedDate[2]), // Year
-    Number(splittedDate[1]), // Month
+    Number(splittedDate[1]) - 1, // Month
     Number(splittedDate[0]), // Day
   ).toISOString();
 };

--- a/public/rss.xml
+++ b/public/rss.xml
@@ -4,7 +4,7 @@
         <description><![CDATA[Robert Orliński | Programuję i dzielę się wiedzą o programowaniu 🚀]]></description>
         <link>http://localhost:3000</link>
         <generator>RSS for Node</generator>
-        <lastBuildDate>Sat, 02 Jul 2022 10:55:08 GMT</lastBuildDate>
+        <lastBuildDate>Sat, 16 Jul 2022 23:49:15 GMT</lastBuildDate>
         <atom:link href="http://localhost:3000/rss.xml" rel="self" type="application/rss+xml"/>
         <copyright><![CDATA[2022 Robert Orliński]]></copyright>
         <language><![CDATA[pl]]></language>


### PR DESCRIPTION
Subtract 1 from `monthIndex` value in `new Date` constructor to generate correct ISO 8601 date string from provided `publicationDate` string.

As we can read in [documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/Date#parameters): 
"`monthIndex` - Integer value representing the month, beginning with 0 for January to 11 for December."