### PR TITLE
Time standardization to UTC in getISOStringFromPublicationDate.ts (fix #13 issue)

### DIFF
--- a/helpers/functions/getISOStringFromPublicationDate.ts
+++ b/helpers/functions/getISOStringFromPublicationDate.ts
@@ -2,9 +2,11 @@ const getISOStringFromPublicationDate = (date: string): string => {
   const splittedDate = date.split('.');
 
   return new Date(
-    Number(splittedDate[2]), // Year
-    Number(splittedDate[1]) - 1, // Month
-    Number(splittedDate[0]), // Day
+    Date.UTC(
+      Number(splittedDate[2]), // Year
+      Number(splittedDate[1]) - 1, // Month
+      Number(splittedDate[0]), // Day
+    ),
   ).toISOString();
 };
 

--- a/public/rss.xml
+++ b/public/rss.xml
@@ -4,7 +4,7 @@
         <description><![CDATA[Robert Orliński | Programuję i dzielę się wiedzą o programowaniu 🚀]]></description>
         <link>http://localhost:3000</link>
         <generator>RSS for Node</generator>
-        <lastBuildDate>Sat, 16 Jul 2022 23:49:15 GMT</lastBuildDate>
+        <lastBuildDate>Sun, 17 Jul 2022 16:08:21 GMT</lastBuildDate>
         <atom:link href="http://localhost:3000/rss.xml" rel="self" type="application/rss+xml"/>
         <copyright><![CDATA[2022 Robert Orliński]]></copyright>
         <language><![CDATA[pl]]></language>


### PR DESCRIPTION
Possibly simpler solution to fix #13 issue without using any external library.

Changes in this PR standardize the date to UTC time by using `Date.UTC` method.